### PR TITLE
Add support for new ChatGPT models

### DIFF
--- a/ChatGPT3DS/main.lua
+++ b/ChatGPT3DS/main.lua
@@ -53,8 +53,19 @@ local settingsItems = {
 local menuSelection = 1
 
 local chatModel = 1
-local CHAT_MODELS = {"gpt-3.5-turbo", "gpt-4"}
-local CHAT_COSTS = {0.002, 0.03} -- Cost per 1K tokens
+local CHAT_MODELS = {
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-16k",
+    "gpt-4",
+    "gpt-4-32k"
+}
+-- Rough cost per 1K tokens for displaying an estimate
+local CHAT_COSTS = {
+    0.002,
+    0.004,
+    0.03,
+    0.06
+}
 
 local keyboardTrigger = false
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ChatGPT3DS
 
 A 3DS Application that allows you to make calls to OpenAI's chat completion API and image generation API.
+The application now supports additional ChatGPT models including `gpt-3.5-turbo-16k` and `gpt-4-32k`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add `gpt-3.5-turbo-16k` and `gpt-4-32k` as selectable models
- note model support in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffa390a0c8326b324c91bfa276ebb