### PR TITLE
Add support for additional OpenAI models

### DIFF
--- a/ChatGPT3DS/main.lua
+++ b/ChatGPT3DS/main.lua
@@ -53,8 +53,23 @@ local settingsItems = {
 local menuSelection = 1
 
 local chatModel = 1
-local CHAT_MODELS = {"gpt-3.5-turbo", "gpt-4"}
-local CHAT_COSTS = {0.002, 0.03} -- Cost per 1K tokens
+local CHAT_MODELS = {
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-16k",
+    "gpt-4",
+    "gpt-4-32k",
+    "gpt-4-turbo",
+    "gpt-4o"
+}
+-- Rough cost per 1K tokens for displaying an estimate
+local CHAT_COSTS = {
+    0.002,  -- gpt-3.5-turbo
+    0.007,  -- gpt-3.5-turbo-16k
+    0.09,   -- gpt-4
+    0.18,   -- gpt-4-32k
+    0.04,   -- gpt-4-turbo
+    0.02    -- gpt-4o
+}
 
 local keyboardTrigger = false
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChatGPT3DS
 
-A 3DS Application that allows you to make calls to OpenAI's chat completion API and image generation API.
+A 3DS Application that allows you to make calls to OpenAI's chat completion API and image generation API. The application now supports additional ChatGPT models including `gpt-3.5-turbo-16k`, `gpt-4-32k`, `gpt-4-turbo`, and `gpt-4o`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- include gpt-4-turbo and gpt-4o in selectable models
- update token pricing for all models
- document supported models in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ffa390a0c8326b324c91bfa276ebb